### PR TITLE
Update regex paths to only match home folder library

### DIFF
--- a/Daemon/Daemon/watchList.plist
+++ b/Daemon/Daemon/watchList.plist
@@ -21,7 +21,7 @@
 		<string>Launch D &amp; A</string>
 		<key>paths</key>
 		<array>
-			<string>^(\/System|\/Users\/.+|)\/Library\/(LaunchDaemons|LaunchAgents)\/.+\.(?i)plist$</string>
+			<string>^(\/System|\/Users\/[^\/]+|)\/Library\/(LaunchDaemons|LaunchAgents)\/.+\.(?i)plist$</string>
 		</array>
 		<key>class</key>
 		<string>Launchd</string>
@@ -35,7 +35,7 @@
 		<string>Login Item</string>
 		<key>paths</key>
 		<array>
-			<string>^(\/Users\/.+|)\/Library\/Application Support\/com.apple.backgroundtaskmanagementagent\/backgrounditems.btm$</string>
+			<string>^(\/Users\/[^\/]+|)\/Library\/Application Support\/com.apple.backgroundtaskmanagementagent\/backgrounditems.btm$</string>
 		</array>
 		<key>class</key>
 		<string>LoginItem</string>


### PR DESCRIPTION
This changes the regex so that only 1 folder can be detected between `/Users` and `/Library` which should be the users home folder. This fixes a bug where BlockBlock would falsely alert the user that a launch agent or daemon was installed when in reality it existed in a deeper folder structure such as `/Users/test/Downloads/Library/LaunchAgents/com.test.plist`

This should fix https://github.com/objective-see/BlockBlock/issues/38

If the described behaviour is not the goal of BlockBlock please feel free to close this PR.  Thanks!