### PR TITLE
Update URLs to use the .org tld

### DIFF
--- a/Shared/consts.h
+++ b/Shared/consts.h
@@ -74,13 +74,13 @@
 #define RULE_STATE_ALLOW 1
 
 //product version url
-#define PRODUCT_VERSIONS_URL @"https://objective-see.com/products.json"
+#define PRODUCT_VERSIONS_URL @"https://objective-see.org/products.json"
 
 //product url
-#define PRODUCT_URL @"https://objective-see.com/products/blockblock.html"
+#define PRODUCT_URL @"https://objective-see.org/products/blockblock.html"
 
 //error(s) url
-#define ERRORS_URL @"https://objective-see.com/errors.html"
+#define ERRORS_URL @"https://objective-see.org/errors.html"
 
 //support us button tag
 #define BUTTON_SUPPORT_US 100
@@ -144,7 +144,7 @@
 #define LOG_FILE_NAME @"BlockBlock.log"
 
 //general error URL
-#define FATAL_ERROR_URL @"https://objective-see.com/errors.html"
+#define FATAL_ERROR_URL @"https://objective-see.org/errors.html"
 
 //key for exit code
 #define EXIT_CODE @"exitCode"


### PR DESCRIPTION
The objective-see.com URLs are redirected to their objective-see.org
counterparts. An HTTP requests to the `PRODUCT_URL` will therefore
result in a `301` response and a subsequent request to the URL from the
`location` header of the response.

Update all URLs to skip that step and request the correct URL in the
first attempt.


Before:

```
curl -I https://objective-see.com/products.json
HTTP/2 301 
location: https://objective-see.org/products.json
date: Thu, 01 Sep 2022 08:05:07 GMT
content-type: text/html; charset=UTF-8
server: ghs
content-length: 236
x-xss-protection: 0
x-frame-options: SAMEORIGIN
```

After:

```
curl -I https://objective-see.org/products.json
HTTP/2 200 
server: GitHub.com
content-type: application/json; charset=utf-8
x-origin-cache: HIT
last-modified: Thu, 18 Aug 2022 02:21:16 GMT
access-control-allow-origin: *
etag: "62fda21c-123c"
expires: Thu, 01 Sep 2022 08:08:21 GMT
cache-control: max-age=600
x-proxy-cache: MISS
x-github-request-id: AEB4:72A6:568C1F:5AD877:6310661D
accept-ranges: bytes
date: Thu, 01 Sep 2022 08:05:35 GMT
via: 1.1 varnish
...
```

Same for the other URLs:

```
curl -I https://objective-see.com/products/blockblock.html
HTTP/2 301 
location: https://objective-see.org/products/blockblock.html
date: Thu, 01 Sep 2022 08:06:08 GMT
content-type: text/html; charset=UTF-8
server: ghs
content-length: 247
x-xss-protection: 0
x-frame-options: SAMEORIGIN
```

```
curl -I https://objective-see.com/errors.html
HTTP/2 301 
location: https://objective-see.org/errors.html
date: Thu, 01 Sep 2022 08:06:50 GMT
content-type: text/html; charset=UTF-8
server: ghs
content-length: 234
x-xss-protection: 0
x-frame-options: SAMEORIGIN
```
