### PR TITLE
Optimize event processing performance

### DIFF
--- a/Daemon/Daemon/Monitor.m
+++ b/Daemon/Daemon/Monitor.m
@@ -556,19 +556,13 @@ bail:
     __block PluginBase* plugin = nil;
     
     //look for plugin that can handle path
-    [plugins enumerateObjectsUsingBlock:^(PluginBase* currentPlugin, NSUInteger index, BOOL* stop)
-    {
+    NSUInteger idx = [plugins indexOfObjectWithOptions:NSEnumerationConcurrent passingTest:^BOOL(PluginBase * _Nonnull currentPlugin, NSUInteger idx, BOOL * _Nonnull stop) {
         //is match?
-        if(YES == [currentPlugin isMatch:file])
-        {
-            //save
-            plugin = currentPlugin;
-            
-            //stop
-            *stop = YES;
-        }
+        return [currentPlugin isMatch:file];
     }];
-    
+    if (idx != NSNotFound) {
+        plugin = plugins[idx];
+    }
     return plugin;
 }
 

--- a/Daemon/Daemon/Monitor.m
+++ b/Daemon/Daemon/Monitor.m
@@ -323,6 +323,31 @@ bail:
     //dbg msg
     logMsg(LOG_DEBUG, [NSString stringWithFormat:@"created event: %@", event]);
     
+    //matches last event?
+    // if so, ignore the event
+    if(YES == [event isRelated:self.lastEvent])
+    {
+        //dbg msg
+        logMsg(LOG_DEBUG, @"matches last event, so ignoring");
+
+        //update
+        self.lastEvent = event;
+
+        //skip
+        goto bail;
+    }
+
+    //ignore (closely) matched alerts
+    // ...that were already shown to user
+    if(YES == [events wasShown:event])
+    {
+        //dbg msg
+        logMsg(LOG_DEBUG, [NSString stringWithFormat:@"event %@ matches/is related to a shown alert, so ignoring", event]);
+
+        //skip
+        goto bail;
+    }
+
     //any matching rules?
     // do this here, since we need an event and plugin obj
     matchingRule = [rules find:event];
@@ -357,34 +382,9 @@ bail:
     
     //dbg msg
     logMsg(LOG_DEBUG, @"no matching rule found...");
-        
-    //matches last event?
-    // if so, ignore the event
-    if(YES == [event isRelated:self.lastEvent])
-    {
-        //dbg msg
-        logMsg(LOG_DEBUG, @"matches last event, so ignoring");
-        
-        //update
-        self.lastEvent = event;
-        
-        //skip
-        goto bail;
-    }
     
     //update
     self.lastEvent = event;
-    
-    //ignore (closely) matched alerts
-    // ...that were already shown to user
-    if(YES == [events wasShown:event])
-    {
-        //dbg msg
-        logMsg(LOG_DEBUG, [NSString stringWithFormat:@"event %@ matches/is related to a shown alert, so ignoring", event]);
-        
-        //skip
-        goto bail;
-    }
     
     //dbg msg
     logMsg(LOG_DEBUG, @"event appears to be new!, will deliver");

--- a/Daemon/Daemon/PluginBase.m
+++ b/Daemon/Daemon/PluginBase.m
@@ -76,27 +76,25 @@
     path = file.destinationPath;
     
     //match?
-    [self.regexes enumerateObjectsUsingBlock:^(NSRegularExpression* regex, NSUInteger index, BOOL * _Nonnull stop) {
-        
+    [self.regexes enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(NSRegularExpression* _Nonnull regex, NSUInteger idx, BOOL * _Nonnull stop) {
         //match
         NSTextCheckingResult* match = nil;
-        
+
         //is match?
         match = [regex firstMatchInString:path options:0 range:NSMakeRange(0, path.length)];
         if( (nil == match) ||
-            (NSNotFound == match.range.location) )
+           (NSNotFound == match.range.location) )
         {
             //no match
             // keep checking
             return;
         }
-        
+
         //got match
         matched = YES;
-            
+
         //done
         *stop = YES;
-        
     }];
     
     return matched;


### PR DESCRIPTION
Resolves #68; Resolves #65

## Description

This PR addresses for-loop iterations not being concurrent, as well as resolves a couple of issues with the project, specifically - Xcode static code analyzer showed a bug, and Sentry needed to be updated due to an issue with the linker in later versions of Xcode/clang.

## Context

In my attempt to resolve issues while Xcode is running swift compiler, I made a small investigation, and the following was uncovered:

1. when Daemon is running, in its `main` function `Monitor` instance is created
2. then `-[Monitor start]` is called from the same `main` function of the Daemon
3. in `-[Monitor start]` there is the following code:
```objc
FileCallbackBlock block = ^(File* file)
    {
...
            //process file event
            [self processEvent:file];
        }
    };
...
//start monitoring
    started = [self.fileMon start:events count:sizeof(events)/sizeof(events[0]) csOption:csNone callback:block];
```
5. for every file registered by the Monitor (are all files in the system registered, or only some? I do not know exactly), callback is executed. It means that during compilation in Xcode, every file that is being created, written etc. produces these events. Xcode compilation happens in parallel on different cores, thus produces hundreds if not thousands of events.
6. Events arrive via the callback block to `-[Monitor processEvent:]`
7. Upon processing of the event, a "plugin" is being looked up in all registered "plugins":
```objc
// ...that cares about the path/file that was just created
plugin = [self findPlugin:file];
```
8. found "plugin" is an instance of `PluginBase`, the same I have mentioned in the beginning
9. message `-[PluginBase isMatch:]` is sent then, which uses `regex` to match against the given "event", where "event' is a file system event

As can be seen in the sample I have provided in the previous message, ICU library is responsible for such enormous CPU consumption.

## Conclusion

Due to the nature of file processing, it is not that easy to optimize the process when there is such big bulk operation with file reads/writes occurs in the system. 

That being said, there are a few techniques which might improve the situation not only for Xcode, but for all other applications/file operations as well:

1. use parallel enumeration when evaluating "plugin" against the given event
2. use parallel enumeration when searching for a "plugin" in all registered plugins
3. exit early in case the event should be "ignored"

