### PR TITLE
Remove Sentry SDK

### DIFF
--- a/Application/Application.xcodeproj/project.pbxproj
+++ b/Application/Application.xcodeproj/project.pbxproj
@@ -38,7 +38,6 @@
 		CD8FD5F823C05AD900EFE0FB /* RulesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = CD8FD5F323C05AD800EFE0FB /* RulesWindowController.m */; };
 		CD8FD5FA23C05AD900EFE0FB /* Rules.xib in Resources */ = {isa = PBXBuildFile; fileRef = CD8FD5F523C05AD900EFE0FB /* Rules.xib */; };
 		CD8FD5FD23C05C6900EFE0FB /* Rule.m in Sources */ = {isa = PBXBuildFile; fileRef = CD8FD5FC23C05C6900EFE0FB /* Rule.m */; };
-		CDA88A792537CE2400C469BF /* Sentry.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD21501B20AD2EE000CEF17B /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDA995C1291DDB20005592F0 /* BlockBlock Installer.app in Resources */ = {isa = PBXBuildFile; fileRef = CDA995C0291DDB20005592F0 /* BlockBlock Installer.app */; };
 		CDFA08E1214900BF0089758C /* XPCUser.m in Sources */ = {isa = PBXBuildFile; fileRef = CDFA08DF214900BF0089758C /* XPCUser.m */; };
 /* End PBXBuildFile section */
@@ -50,7 +49,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				CDA88A792537CE2400C469BF /* Sentry.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -88,7 +86,6 @@
 		7DD2BF941F1FF64300B33214 /* AlertWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AlertWindow.xib; sourceTree = "<group>"; };
 		7DD2BF951F1FF64300B33214 /* AlertWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AlertWindowController.h; sourceTree = "<group>"; };
 		7DD2BF961F1FF64300B33214 /* AlertWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AlertWindowController.m; sourceTree = "<group>"; };
-		CD21501B20AD2EE000CEF17B /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sentry.framework; path = ../Carthage/Build/Mac/Sentry.framework; sourceTree = "<group>"; };
 		CD22785B20434CAB00C72C76 /* StatusBarPopover.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatusBarPopover.xib; sourceTree = "<group>"; };
 		CD22785C20434CAB00C72C76 /* StatusBarPopoverController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatusBarPopoverController.h; sourceTree = "<group>"; };
 		CD22785D20434CAB00C72C76 /* StatusBarPopoverController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatusBarPopoverController.m; sourceTree = "<group>"; };
@@ -173,7 +170,6 @@
 				CD4597F4291DB39300F2A1C6 /* Uninstaller */,
 				7D3B75201F13356900568828 /* Shared */,
 				7D7755E51F02E05B00D0017D /* Source */,
-				CDAFF434203E55F300F27635 /* Frameworks */,
 				7D7755E41F02E05B00D0017D /* Products */,
 			);
 			sourceTree = "<group>";
@@ -247,14 +243,6 @@
 				CDA995C0291DDB20005592F0 /* BlockBlock Installer.app */,
 			);
 			path = Uninstaller;
-			sourceTree = "<group>";
-		};
-		CDAFF434203E55F300F27635 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				CD21501B20AD2EE000CEF17B /* Sentry.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		CDD5666423AB4CF900F51B1F /* Libraries */ = {

--- a/Application/Application/main.m
+++ b/Application/Application/main.m
@@ -8,7 +8,6 @@
 //
 
 @import Cocoa;
-@import Sentry;
 
 #import "consts.h"
 #import "logging.h"
@@ -29,12 +28,6 @@ int main(int argc, const char * argv[])
     //dbg msg(s)
     logMsg(LOG_DEBUG, [NSString stringWithFormat:@"started: %@", [[[NSBundle mainBundle] infoDictionary] objectForKey:(id)kCFBundleNameKey]]);
     logMsg(LOG_DEBUG, [NSString stringWithFormat:@"arguments: %@", [[NSProcessInfo processInfo] arguments]]);
-    
-    //init crash reporting
-    [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-        options.dsn = SENTRY_DSN;
-        options.debug = YES;
-    }];
     
     //launch app normally
     status = NSApplicationMain(argc, argv);

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "getsentry/sentry-cocoa" "6.0.10"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "getsentry/sentry-cocoa" "6.0.0"

--- a/Daemon/Daemon.xcodeproj/project.pbxproj
+++ b/Daemon/Daemon.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 		CD3913FD238268B300850CD1 /* Rule.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3913FB238268B300850CD1 /* Rule.m */; };
 		CD410454244406EB00069C56 /* LoginItem.m in Sources */ = {isa = PBXBuildFile; fileRef = CD410453244406EB00069C56 /* LoginItem.m */; };
 		CD9E04AB253E845300DB3218 /* Kext.m in Sources */ = {isa = PBXBuildFile; fileRef = CD9E04AA253E845300DB3218 /* Kext.m */; };
-		CDA88A772537CE0500C469BF /* Sentry.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD21501720AD222800CEF17B /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDAABD3E238BA077005AE212 /* Monitor.m in Sources */ = {isa = PBXBuildFile; fileRef = CDAABD3D238BA077005AE212 /* Monitor.m */; };
 		CDAABD48238BA1D3005AE212 /* libEndpointSecurity.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CDAABD47238BA1D3005AE212 /* libEndpointSecurity.tbd */; };
 		CDAABD4A238BA1E2005AE212 /* libbsm.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CDAABD49238BA1E1005AE212 /* libbsm.tbd */; };
@@ -43,7 +42,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				CDA88A772537CE0500C469BF /* Sentry.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -56,7 +54,6 @@
 		7D564DB71F18434F00B8AAD6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = Daemon/Info.plist; sourceTree = "<group>"; };
 		7D564DC61F18441500B8AAD6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = MainMenu.xib; sourceTree = "<group>"; };
 		7D564DC71F18441500B8AAD6 /* AboutWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = AboutWindow.xib; path = ../Daemon/AboutWindow.xib; sourceTree = "<group>"; };
-		CD21501720AD222800CEF17B /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sentry.framework; path = ../Carthage/Build/Mac/Sentry.framework; sourceTree = "<group>"; };
 		CD30BADD22174FAF00E5D96A /* BlockBlock.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = BlockBlock.entitlements; path = Daemon/BlockBlock.entitlements; sourceTree = "<group>"; };
 		CD3913DA2382649E00850CD1 /* XPCListener.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XPCListener.m; path = Daemon/XPCListener.m; sourceTree = "<group>"; };
 		CD3913DB2382649E00850CD1 /* Preferences.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Preferences.m; path = Daemon/Preferences.m; sourceTree = "<group>"; };
@@ -226,7 +223,6 @@
 				CDE3875427B39ACF00752C50 /* libquarantine.tbd */,
 				CDAABD49238BA1E1005AE212 /* libbsm.tbd */,
 				CDAABD47238BA1D3005AE212 /* libEndpointSecurity.tbd */,
-				CD21501720AD222800CEF17B /* Sentry.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Daemon/Daemon/main.m
+++ b/Daemon/Daemon/main.m
@@ -10,8 +10,6 @@
 #import "main.h"
 #import "Monitor.h"
 
-@import Sentry;
-
 /* GLOBALS */
 
 //(file)monitor
@@ -26,12 +24,6 @@ int main(int argc, const char * argv[])
     {
         //dbg msg
         logMsg(LOG_DEBUG, [NSString stringWithFormat:@"launch daemon %@ started with %@", NSProcessInfo.processInfo.arguments.firstObject.lastPathComponent, NSProcessInfo.processInfo.arguments]);
-        
-        //init crash reporting
-        [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-            options.dsn = SENTRY_DSN;
-            options.debug = YES;
-        }];
         
         //not root?
         if(0 != geteuid())

--- a/Installer/Installer.xcodeproj/project.pbxproj
+++ b/Installer/Installer.xcodeproj/project.pbxproj
@@ -30,7 +30,6 @@
 		CD86B6E823A5BBA5003F6BA4 /* com.objective-see.blockblock.plist in Resources */ = {isa = PBXBuildFile; fileRef = CDAFF43F203E971F00F27635 /* com.objective-see.blockblock.plist */; };
 		CD86B6EA23A5BBE7003F6BA4 /* configure.sh in Resources */ = {isa = PBXBuildFile; fileRef = CD86B6E923A5BBE7003F6BA4 /* configure.sh */; };
 		CDA6E639203B6F1000C78F91 /* logging.m in Sources */ = {isa = PBXBuildFile; fileRef = CD17D53820104DD700F798D7 /* logging.m */; };
-		CDA88A752537CDE100C469BF /* Sentry.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD6B484220AD323E00A9BE71 /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDAAC241202255580032F2E6 /* utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = CDAAC23F202255580032F2E6 /* utilities.m */; };
 		CDAAC243202257D70032F2E6 /* utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = CDAAC23F202255580032F2E6 /* utilities.m */; };
 /* End PBXBuildFile section */
@@ -62,7 +61,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				CDA88A752537CDE100C469BF /* Sentry.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,7 +94,6 @@
 		CD2F801024465F68009C3D77 /* patrons.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = patrons.txt; path = ../../Shared/patrons.txt; sourceTree = "<group>"; };
 		CD2F8012244670B9009C3D77 /* libbsm.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbsm.tbd; path = usr/lib/libbsm.tbd; sourceTree = SDKROOT; };
 		CD3307AD203567D400F10D71 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		CD6B484220AD323E00A9BE71 /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sentry.framework; path = ../Carthage/Build/Mac/Sentry.framework; sourceTree = "<group>"; };
 		CD6CAC9120A42D5000188B0A /* main.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = main.h; sourceTree = "<group>"; };
 		CD73DA8F2004629D001FFC84 /* HelperInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HelperInterface.h; sourceTree = "<group>"; };
 		CD73DA902004629D001FFC84 /* HelperInterface.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HelperInterface.m; sourceTree = "<group>"; };
@@ -153,7 +150,6 @@
 			isa = PBXGroup;
 			children = (
 				CD2F8012244670B9009C3D77 /* libbsm.tbd */,
-				CD6B484220AD323E00A9BE71 /* Sentry.framework */,
 				1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */,
 				4BE4906310445F2F006BE471 /* Security.framework */,
 				4BE4906710445F36006BE471 /* ServiceManagement.framework */,

--- a/Installer/Source/main.m
+++ b/Installer/Source/main.m
@@ -8,7 +8,6 @@
 //
 
 @import Cocoa;
-@import Sentry;
 
 #import "main.h"
 #import "consts.h"
@@ -31,12 +30,6 @@ int main(int argc, char *argv[])
 {
     //status
     int status = -1;
-    
-    //init crash reporting
-    [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-        options.dsn = SENTRY_DSN;
-        options.debug = YES;
-    }];
     
     //dbg msg
     logMsg(LOG_DEBUG, [NSString stringWithFormat:@"BlockBlock (in/unin)staller launched with %@", NSProcessInfo.processInfo.arguments]);

--- a/Shared/consts.h
+++ b/Shared/consts.h
@@ -19,9 +19,6 @@
 //patreon url
 #define PATREON_URL @"https://www.patreon.com/join/objective_see"
 
-//sentry crash reporting URL
-#define SENTRY_DSN @"https://04a1d345121247f8b62014d801d7bed2@o130950.ingest.sentry.io/1225145"
-
 //bundle ID
 #define BUNDLE_ID "com.objective-see.blockblock"
 


### PR DESCRIPTION
## Context

According to [this conversation](https://github.com/objective-see/BlockBlock/pull/69#discussion_r1405226834), Sentry SDK integration raises concerns about GDPR. Apart from that, for a security tool, in my opinion, it is nice not to have any dependencies.

Removal of Sentry SDK also removes the burden of maintaining the dependency, as well as streamlining contribution experience for BlockBlock in general, since entry point would become very minimal - no need to install Carthage anymore.

That being said, the next step for BlockBlock might be AppStore distribution? What stops BlockBlock from being distributed via the AppStore? Xcode organizer, for instance, provides a very nice overview of the crashes on enduser macs.